### PR TITLE
meson: unbreak if glamor isn't explicitly enabled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -329,7 +329,7 @@ endif
 module_dir = join_paths(get_option('libdir'), get_option('module_dir'))
 
 if glamor_option == 'auto'
-    build_glamor = build_xorg or build_xwayland
+    build_glamor = build_xorg or build_xwayland or build_xarcan
 else
     build_glamor = glamor_option == 'true'
 endif


### PR DESCRIPTION
Regressed in 0.6.0. See [error log](https://github.com/letoram/xarcan/files/5620133/xarcan-0.6.0.log).