### PR TITLE
fix: early return when arcanInputPriv.pi is NULL

### DIFF
--- a/hw/kdrive/arcan/core.c
+++ b/hw/kdrive/arcan/core.c
@@ -1058,6 +1058,9 @@ static void
 TranslateInput(
     struct arcan_shmif_cont* con, arcan_event* oev, arcanShmifPriv *P)
 {
+    if (!arcanInputPriv.pi)
+        return;
+
     int x = 0, y = 0;
     arcan_ioevent *ev = &oev->io;
 

--- a/hw/kdrive/arcan/core.c
+++ b/hw/kdrive/arcan/core.c
@@ -1158,6 +1158,9 @@ void
 arcanDisplayHint(struct arcan_shmif_cont* con,
                  int w, int h, int fl, int rgb, float ppcm)
 {
+    if (!arcanInputPriv.pi)
+        return;
+
     arcanScrPriv* apriv = con->user;
 
 /* release on focus loss, open point, does this actually cover mods? */
@@ -3361,6 +3364,9 @@ static
 void
 updateWindowFocus(WindowPtr wnd, bool focus)
 {
+    if (!arcanInputPriv.pi)
+        return;
+
     struct XWMHints *hints = getHintsForWindow(wnd);
 
     DeviceIntPtr kdev = arcanInputPriv.ki->dixdev;

--- a/hw/kdrive/arcan/cursor.c
+++ b/hw/kdrive/arcan/cursor.c
@@ -330,6 +330,9 @@ void arcanSynchCursor(arcanScrPriv *scr, Bool softUpdate)
 {
     int x, y;
 
+    if (!arcanInputPriv.pi)
+        return;
+
     if (!arcanInputPriv.pi->dixdev)
         return;
 

--- a/hw/kdrive/arcan/init.c
+++ b/hw/kdrive/arcan/init.c
@@ -115,7 +115,7 @@ InitInput(int argc, char **argv)
         if (!kdHasPointer){
             pi = KdNewPointer();
             if (!pi)
-                FatalError("Couldn't create Xarcan keyboard\n");
+                FatalError("Couldn't create Xarcan pointer input\n");
             pi->driver = &arcanPointerDriver;
             KdAddPointer(pi);
         }
@@ -123,7 +123,7 @@ InitInput(int argc, char **argv)
         if (!kdHasKbd){
             ki = KdNewKeyboard();
             if (!ki)
-                FatalError("Couldn't create Xarcan keyboard\n");
+                FatalError("Couldn't create Xarcan keyboard input\n");
             ki->driver = &arcanKeyboardDriver;
             KdAddKeyboard(ki);
           }


### PR DESCRIPTION
This PR adds checks for `arcanInputPriv.pi`.

The actual problem may be something running before the initialization of the mouse via `MouseInit`

- The first commit adds the checks that caused actual crashes on my machine.
- The second commit adds checks for other possible occurences
- The third commit is just a simple fix of a error message I found out while trying to follow the logic